### PR TITLE
Fix `secret` setting in nodejs setup

### DIFF
--- a/snippets/server-apis/nodejs/setup.md
+++ b/snippets/server-apis/nodejs/setup.md
@@ -4,7 +4,7 @@ var app = express();
 var jwt = require('express-jwt');
 
 var jwtCheck = jwt({
-  secret: '<%= account.clientSecret %>',
+  secret: new Buffer('<%= account.clientSecret %>', 'base64'),
   audience: '<%= account.clientId %>'
 });
 ```


### PR DESCRIPTION
<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors.
- Please include a short description
- If your PR is a work in progress title it [DO NOT MERGE]
--->

Seems like `account.clientSecret` contains base64-encoded secret.

https://github.com/auth0/express-jwt#usage